### PR TITLE
Don't fail on invalid image

### DIFF
--- a/lib/sprockets/webp/converter.rb
+++ b/lib/sprockets/webp/converter.rb
@@ -31,7 +31,7 @@ module Sprockets
 
           # Encode Original File Temp copy to WebP File Pathname
           begin
-            ::WebP.encode(file.path, webp_path.to_path) 
+            ::WebP.encode(file.path, webp_path.to_path, quality: 90) 
           rescue => e
             $stdout.puts "WARNING: Webp convertion error for image #{file_name}. Error: #{e.message}"
           end


### PR DESCRIPTION
Sometimes some gems have invalid images inside. In this case task assets:precompile should skip this type of images :)  
