### PR TITLE
Fix logger and trying to fix codeclimate

### DIFF
--- a/lib/sprockets/webp/converter.rb
+++ b/lib/sprockets/webp/converter.rb
@@ -1,43 +1,68 @@
 # encoding: utf-8
 
 require 'tempfile'
+require 'logger'
 require 'fileutils'
 require 'webp-ffi'
 
 module Sprockets
   module WebP
     class Converter
-      def self.process(app, context, data)
-        # Application Config alias
-        config = app.config.assets
+      class << self
 
-        # If Application Assets Digests enabled - Add Digest
-        digest    = config.digest ? "-#{context.environment.digest.update(data).hexdigest}" : nil
-        file_name = context.logical_path # Original File name w/o extension
-        file_ext  = context.pathname.extname # Original File extension
-        webp_file = "#{file_name}#{digest}#{file_ext}.webp" # WebP File fullname
+        attr_reader :context
 
-        # WebP File Pathname
-        webp_path = Pathname.new File.join(app.root, 'public', config.prefix, webp_file)
+        def process(app, context, data)
+          @context = context
+          # Application Config alias
+          config = app.config.assets
 
-        # Create Directory for both Files, unless already exists
-        FileUtils.mkdir_p(webp_path.dirname) unless Dir.exists?(webp_path.dirname)
+          # If Application Assets Digests enabled - Add Digest
+          digest    = config.digest ? "-#{context.environment.digest.update(data).hexdigest}" : nil
+          file_name = context.logical_path # Original File name w/o extension
+          file_ext  = context.pathname.extname # Original File extension
+          webp_file = "#{file_name}#{digest}#{file_ext}.webp" # WebP File fullname
 
-        # Create Temp File with Original File binary data
-        Tempfile.open('webp') do |file|
-          file.binmode
-          file.write(data)
-          file.close
+          # WebP File Pathname
+          webp_path = Pathname.new File.join(app.root, 'public', config.prefix, webp_file)
 
-          # Encode Original File Temp copy to WebP File Pathname
-          begin
-            ::WebP.encode(file.path, webp_path.to_path, Sprockets::WebP.encode_options)
-          rescue => e
-            $stdout.puts "WARNING: Webp convertion error for image #{file_name}. Error: #{e.message}"
+          # Create Directory for both Files, unless already exists
+          FileUtils.mkdir_p(webp_path.dirname) unless Dir.exists?(webp_path.dirname)
+
+          # encode to webp
+          encode_to_webp(data, webp_path.to_path, webp_file)
+
+          data
+        end
+
+        private
+
+        def encode_to_webp(data, webp_path, webp_file = "")
+          # Create Temp File with Original File binary data
+          Tempfile.open('webp') do |file|
+            file.binmode
+            file.write(data)
+            file.close
+
+            # Encode Original File Temp copy to WebP File Pathname
+            begin
+              ::WebP.encode(file.path, webp_path, Sprockets::WebP.encode_options)
+            rescue => e
+              logger.warn "Webp convertion error of image #{webp_file}. Error info: #{e.message}"
+            end
           end
         end
 
-        data
+        def logger
+          if @context && @context.environment
+            @context.environment.logger
+          else
+            logger = Logger.new($stderr)
+            logger.level = Logger::FATAL
+            logger
+          end
+        end
+
       end
     end
   end


### PR DESCRIPTION
Fix logger for assets pipeline:

``` bash
** [out :: xxx] W, [2013-11-23T14:13:18.572971 #11230]  WARN -- : Webp convertion error of image active_admin/admin_notes_icon-27fadf658c2613c80e13bd19fa58912f.png.webp. Error info: Cannot read input picture file
** [out :: xxx] I, [2013-11-23T14:13:18.573974 #11230]  INFO -- : Writing /var/www/falcon-web/releases/20131123141135/public/assets/active_admin/admin_notes_icon-27fadf658c2613c80e13bd19fa58912f.png
```

 and trying to fix codeclimate: https://codeclimate.com/github/kavu/sprockets-webp/Sprockets::WebP::Converter?from_sha=4aa136f2&to_sha=15755e9a
