### PR TITLE
Drop support of rails 3

### DIFF
--- a/lib/sprockets/webp/converter.rb
+++ b/lib/sprockets/webp/converter.rb
@@ -35,7 +35,7 @@ module Sprockets
         private
 
         def webp_file_by_config(config, data)
-          digest    = config.digest ? "-#{context.environment.digest.update(data).hexdigest}" : nil
+          digest    = config.digest ? "-#{context.environment.digest_class.new.update(data).to_s}" : nil
           file_name = context.logical_path # Original File name w/o extension
           file_ext  = context.pathname.extname # Original File extension
           "#{file_name}#{digest}#{file_ext}.webp" # WebP File fullname

--- a/lib/sprockets/webp/railtie.rb
+++ b/lib/sprockets/webp/railtie.rb
@@ -3,15 +3,17 @@
 module Sprockets
   module WebP
     class Railtie < ::Rails::Railtie
-      initializer :webp do |app|
-        app.assets.register_mime_type 'image/jpeg', '.jpg'
-        app.assets.register_postprocessor 'image/jpeg', :jpeg_webp do |context, data|
-          Converter.process(app, context, data)
-        end
+      initializer :webp, group: :all do |app|
+        app.config.assets.configure do |env|
+          env.register_mime_type 'image/jpeg', '.jpeg'
+          env.register_postprocessor 'image/jpeg', :jpeg_webp do |context, data|
+            Converter.process(app, context, data)
+          end
 
-        app.assets.register_mime_type 'image/png', '.png'
-        app.assets.register_postprocessor 'image/png', :png_webp do |context, data|
-          Converter.process(app, context, data)
+          env.register_mime_type 'image/png', '.png'
+          env.register_postprocessor 'image/png', :png_webp do |context, data|
+            Converter.process(app, context, data)
+          end
         end
       end
     end

--- a/lib/sprockets/webp/railtie.rb
+++ b/lib/sprockets/webp/railtie.rb
@@ -2,7 +2,7 @@
 
 module Sprockets
   module WebP
-    class Railtie < (::Rails::VERSION::MAJOR < 4 ? ::Rails::Engine : ::Rails::Railtie)
+    class Railtie < ::Rails::Railtie
       initializer :webp do |app|
         app.assets.register_mime_type 'image/jpeg', '.jpg'
         app.assets.register_postprocessor 'image/jpeg', :jpeg_webp do |context, data|

--- a/sprockets-webp.gemspec
+++ b/sprockets-webp.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_dependency 'sprockets', '~> 2.2'
+  spec.add_dependency 'sprockets', '> 3'
   spec.add_dependency 'webp-ffi', '~> 0.2.0'
 
   spec.add_development_dependency 'bundler', '~> 1.3'


### PR DESCRIPTION
This pull-req drop support of Rails 3 and it supports Rails 5 :tada: 

## Problem Summary

`sprockets-webp` doesn't support Rails 5 so if I introduce it, my project has broken to run `assets:precompile`.

## Changes

- Support Rails 5
- Drop support of Rails 3
- Drop support of Sprockets under `2.x.x`

